### PR TITLE
load data on-demand when a field is accessed

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ Ruby Hikvision Interface
 require 'hikvision'
 
 cam = Hikvision::ISAPI.new('192.168.0.32', 'user', 'password')
-cam.streaming.load_channels
 
 channel = cam.streaming.channel(101)
 

--- a/examples/configurate-camera.rb
+++ b/examples/configurate-camera.rb
@@ -1,7 +1,6 @@
 require 'hikvision'
 
 cam = Hikvision::ISAPI.new('192.168.0.32', 'user', 'password')
-cam.streaming.load_channels
 
 channel = cam.streaming.channel(101)
 

--- a/examples/jpeg-camera.rb
+++ b/examples/jpeg-camera.rb
@@ -3,7 +3,6 @@ require 'hikvision'
 f = File.open('img.jpeg', 'w+b')
 
 cam = Hikvision::ISAPI.new('192.168.0.32', 'user', 'password')
-cam.streaming.load_channels
 
 channel = cam.streaming.channel(101)
 

--- a/exe/hikvision
+++ b/exe/hikvision
@@ -58,14 +58,12 @@ class App
 
   command :model do |c|
     c.action do
-      @cam.system.load_device_info
       puts @cam.system.model
     end
   end
 
   command :serial do |c|
     c.action do
-      @cam.system.load_device_info
       puts @cam.system.serial
     end
   end
@@ -73,7 +71,6 @@ class App
   desc 'Shows the device id'
   command :id do |c|
     c.action do
-      @cam.system.load_device_info
       puts @cam.system.id
     end
   end
@@ -81,14 +78,12 @@ class App
   desc 'Shows the device description'
   command :desc do |c|
     c.action do
-      @cam.system.load_device_info
       puts @cam.system.description
     end
   end
 
   command :mac do |c|
     c.action do
-      @cam.system.load_device_info
       puts @cam.system.mac_address
     end
   end
@@ -102,7 +97,6 @@ class App
   desc 'List available channels'
   command :channels do |c|
     c.action do
-      @cam.streaming.load_channels
       puts @cam.streaming.channels.collect { |ch| ch.id }
     end
   end
@@ -141,7 +135,6 @@ class App
       id = args[0]
       exit_now! 'channel id must be an integer', 1 if id.to_i.to_s != id
       id = id.to_i
-      @cam.streaming.load_channels
       ch = @cam.streaming.channel(id)
       exit_now! "channel id doesn't exists", 1 if ch.nil?
 
@@ -179,7 +172,6 @@ class App
         next unless opts[k]
 
         edited = true
-        ch.load_opts
         break
       end
 

--- a/lib/hikvision/streaming.rb
+++ b/lib/hikvision/streaming.rb
@@ -2,23 +2,26 @@ module Hikvision
   class Streaming
     def initialize(isapi)
       @isapi = isapi
-      @channels = {}
     end
 
     def channels
-      @channels.values
+      load_channels.values
     end
 
     def channel(id)
-      @channels[id]
+      load_channels[id]
     end
 
     def load_channels(options = {})
+      return @channels if options.fetch(:cache, true) && instance_variable_defined?(:@channels)
+
+      @channels = {}
       xml = @isapi.get_xml('/ISAPI/Streaming/channels', options)
       xml.xpath('StreamingChannelList/StreamingChannel').each do |c|
         channel = Hikvision::StreamingChannel.new(@isapi, c)
         @channels[channel.id] = channel
       end
+      @channels
     end
   end
 end

--- a/lib/hikvision/streaming/channel.rb
+++ b/lib/hikvision/streaming/channel.rb
@@ -1,65 +1,71 @@
 module Hikvision
   class StreamingChannel < Hikvision::Base
-    attr_reader :xml, :cxml
-
     def initialize(isapi, xml)
       @isapi = isapi
-      @xml = xml
+      @base_xml = xml
     end
 
-    add_getter(:id, :@xml, 'id', :to_i)
-    add_getter(:name, :@xml, 'channelName', :to_s)
-    add_getter(:max_packet_size, :@xml, 'Transport/maxPacketSize', :to_i)
-    add_getter(:auth_type, :@xml, 'Transport/Security/certificateType', :to_s)
-    add_getter(:video_framerate, :@xml, 'Video/maxFrameRate', :to_i)
-    add_getter(:video_resolution_width, :@xml, 'Video/videoResolutionWidth', :to_i)
-    add_getter(:video_resolution_height, :@xml, 'Video/videoResolutionHeight', :to_i)
-    add_getter(:video_cbitrate, :@xml, 'Video/constantBitRate', :to_i)
-    add_getter(:video_keyframe_interval, :@xml, 'Video/keyFrameInterval', :to_i)
-    add_getter(:video_codec, :@xml, 'Video/videoCodecType', :to_s)
-    add_getter(:video_bitrate_type, :@xml, 'Video/videoQualityControlType', :to_s)
-    add_getter(:video_scan_type, :@xml, 'Video/videoScanType', :to_s)
-    add_getter(:snapshot_image_type, :@xml, 'Video/snapShotImageType', :to_s)
-    add_getter(:audio_codec, :@xml, 'Audio/audioCompressionType', :to_s)
-    add_getter(:video_smoothing, :@xml, 'Video/smoothing', :to_i)
+    add_xml(:base, -> { url }, 'StreamingChannel')
 
-    add_bool_getter(:enabled?, :@xml, 'enabled')
-    add_bool_getter(:svc_enabled?, :@xml, 'Video/SVC/enabled')
-    add_bool_getter(:video_enabled?, :@xml, 'Video/enabled')
-    add_bool_getter(:audio_enabled?, :@xml, 'Audio/enabled')
-    add_bool_getter(:multicast_enabled?, :@xml, 'Transport/Multicast/enabled')
-    add_bool_getter(:unicast_enabled?, :@xml, 'Transport/Unicast/enabled')
-    add_bool_getter(:security_enabled?, :@xml, 'Transport/Security/enabled')
+    def reload(options = {})
+      load_base(options.merge(cache: false))
+    end
 
-    add_setter(:name=, :@xml, 'channelName', [String])
-    add_setter(:video_framerate=, :@xml, 'Video/maxFrameRate', [Integer])
-    add_setter(:video_codec=, :@xml, 'Video/videoCodecType', [String])
-    add_setter(:audio_codec=, :@xml, 'Audio/audioCompressionType', [String])
-    add_setter(:video_keyframe_interval=, :@xml, 'Video/keyFrameInterval', [Integer])
-    add_setter(:video_cbitrate=, :@xml, 'Video/constantBitRate', [Integer])
-    add_setter(:video_resolution_width=, :@xml, 'Video/videoResolutionWidth', [Integer])
-    add_setter(:video_resolution_height=, :@xml, 'Video/videoResolutionHeight', [Integer])
-    add_setter(:video_bitrate_type=, :@xml, 'Video/videoQualityControlType', [String])
-    add_setter(:video_scan_type=, :@xml, 'Video/videoScanType', [String])
-    add_setter(:snapshot_image_type=, :@xml, 'Video/snapShotImageType', [String])
-    add_setter(:auth_type=, :@xml, 'Transport/Security/certificateType', [String])
-    add_setter(:audio_enabled=, :@xml, 'Audio/enabled', [TrueClass, FalseClass])
-    add_setter(:svc_enabled=, :@xml, 'Video/SVC/enabled', [TrueClass, FalseClass])
+    add_getter(:id, :base, 'id', :to_i)
+    add_getter(:name, :base, 'channelName', :to_s)
+    add_getter(:max_packet_size, :base, 'Transport/maxPacketSize', :to_i)
+    add_getter(:auth_type, :base, 'Transport/Security/certificateType', :to_s)
+    add_getter(:video_framerate, :base, 'Video/maxFrameRate', :to_i)
+    add_getter(:video_resolution_width, :base, 'Video/videoResolutionWidth', :to_i)
+    add_getter(:video_resolution_height, :base, 'Video/videoResolutionHeight', :to_i)
+    add_getter(:video_cbitrate, :base, 'Video/constantBitRate', :to_i)
+    add_getter(:video_keyframe_interval, :base, 'Video/keyFrameInterval', :to_i)
+    add_getter(:video_codec, :base, 'Video/videoCodecType', :to_s)
+    add_getter(:video_bitrate_type, :base, 'Video/videoQualityControlType', :to_s)
+    add_getter(:video_scan_type, :base, 'Video/videoScanType', :to_s)
+    add_getter(:snapshot_image_type, :base, 'Video/snapShotImageType', :to_s)
+    add_getter(:audio_codec, :base, 'Audio/audioCompressionType', :to_s)
+    add_getter(:video_smoothing, :base, 'Video/smoothing', :to_i)
 
-    add_opt_getter(:video_codec_opts, :@cxml, 'Video/videoCodecType', :to_s)
-    add_opt_getter(:audio_codec_opts, :@cxml, 'Audio/audioCompressionType', :to_s)
-    add_opt_getter(:video_bitrate_type_opts, :@cxml, 'Video/videoQualityControlType', :to_s)
-    add_opt_getter(:video_scan_type_opts, :@cxml, 'Video/videoScanType', :to_s)
-    add_opt_getter(:video_resolution_width_opts, :@cxml, 'Video/videoResolutionWidth', :to_i)
-    add_opt_getter(:video_resolution_height_opts, :@cxml, 'Video/videoResolutionHeight', :to_i)
-    add_opt_getter(:snapshot_image_type_opts, :@cxml, 'Video/snapShotImageType', :to_s)
-    add_opt_getter(:video_framerate_opts, :@cxml, 'Video/maxFrameRate', :to_i)
-    add_opt_getter(:auth_type_opts, :@cxml, 'Transport/Security/certificateType', :to_s)
+    add_bool_getter(:enabled?, :base, 'enabled')
+    add_bool_getter(:svc_enabled?, :base, 'Video/SVC/enabled')
+    add_bool_getter(:video_enabled?, :base, 'Video/enabled')
+    add_bool_getter(:audio_enabled?, :base, 'Audio/enabled')
+    add_bool_getter(:multicast_enabled?, :base, 'Transport/Multicast/enabled')
+    add_bool_getter(:unicast_enabled?, :base, 'Transport/Unicast/enabled')
+    add_bool_getter(:security_enabled?, :base, 'Transport/Security/enabled')
 
-    add_opt_range_getter(:video_smoothing_opts, :@cxml, 'Video/smoothing')
-    add_opt_range_getter(:video_cbitrate_opts, :@cxml, 'Video/constantBitRate')
-    add_opt_range_getter(:video_keyframe_interval_opts, :@cxml, 'Video/keyFrameInterval')
-    add_opt_range_getter(:name_length_opts, :@cxml, 'channelName')
+    add_setter(:name=, :base, 'channelName', [String])
+    add_setter(:video_framerate=, :base, 'Video/maxFrameRate', [Integer])
+    add_setter(:video_codec=, :base, 'Video/videoCodecType', [String])
+    add_setter(:audio_codec=, :base, 'Audio/audioCompressionType', [String])
+    add_setter(:video_keyframe_interval=, :base, 'Video/keyFrameInterval', [Integer])
+    add_setter(:video_cbitrate=, :base, 'Video/constantBitRate', [Integer])
+    add_setter(:video_resolution_width=, :base, 'Video/videoResolutionWidth', [Integer])
+    add_setter(:video_resolution_height=, :base, 'Video/videoResolutionHeight', [Integer])
+    add_setter(:video_bitrate_type=, :base, 'Video/videoQualityControlType', [String])
+    add_setter(:video_scan_type=, :base, 'Video/videoScanType', [String])
+    add_setter(:snapshot_image_type=, :base, 'Video/snapShotImageType', [String])
+    add_setter(:auth_type=, :base, 'Transport/Security/certificateType', [String])
+    add_setter(:audio_enabled=, :base, 'Audio/enabled', [TrueClass, FalseClass])
+    add_setter(:svc_enabled=, :base, 'Video/SVC/enabled', [TrueClass, FalseClass])
+
+    add_xml(:capabilities, -> { "#{url}/capabilities" }, "StreamingChannel" )
+
+    add_opt_getter(:video_codec_opts, :capabilities, 'Video/videoCodecType', :to_s)
+    add_opt_getter(:audio_codec_opts, :capabilities, 'Audio/audioCompressionType', :to_s)
+    add_opt_getter(:video_bitrate_type_opts, :capabilities, 'Video/videoQualityControlType', :to_s)
+    add_opt_getter(:video_scan_type_opts, :capabilities, 'Video/videoScanType', :to_s)
+    add_opt_getter(:video_resolution_width_opts, :capabilities, 'Video/videoResolutionWidth', :to_i)
+    add_opt_getter(:video_resolution_height_opts, :capabilities, 'Video/videoResolutionHeight', :to_i)
+    add_opt_getter(:snapshot_image_type_opts, :capabilities, 'Video/snapShotImageType', :to_s)
+    add_opt_getter(:video_framerate_opts, :capabilities, 'Video/maxFrameRate', :to_i)
+    add_opt_getter(:auth_type_opts, :capabilities, 'Transport/Security/certificateType', :to_s)
+
+    add_opt_range_getter(:video_smoothing_opts, :capabilities, 'Video/smoothing')
+    add_opt_range_getter(:video_cbitrate_opts, :capabilities, 'Video/constantBitRate')
+    add_opt_range_getter(:video_keyframe_interval_opts, :capabilities, 'Video/keyFrameInterval')
+    add_opt_range_getter(:name_length_opts, :capabilities, 'channelName')
 
     def video_resolution
       [video_resolution_width, video_resolution_height]
@@ -78,20 +84,12 @@ module Hikvision
       @isapi.get("#{url}/picture", options).response.body
     end
 
-    def reload(options = {})
-      @xml = @isapi.get_xml(url, options).at_xpath('StreamingChannel')
-    end
-
     def edit(options = {})
-      options[:body] = @xml.xpath('/').to_s
+      options[:body] = @base_xml.xpath('/').to_s
 
       @isapi.cache.delete('/ISAPI/Streaming/channels')
 
       @isapi.put(url, options)
-    end
-
-    def load_opts(options = {})
-      @cxml = @isapi.get_xml("#{url}/capabilities", options).at_xpath('StreamingChannel')
     end
 
     def url

--- a/lib/hikvision/system/device_info.rb
+++ b/lib/hikvision/system/device_info.rb
@@ -1,25 +1,21 @@
 module Hikvision
   class System
-    attr_reader :dxml
+    add_xml(:device_info, '/ISAPI/System/deviceInfo', 'DeviceInfo')
 
-    add_getter(:name, :@dxml, 'deviceName', :to_s)
-    add_getter(:id, :@dxml, 'deviceID', :to_s)
-    add_getter(:description, :@dxml, 'deviceDescription', :to_s)
-    add_getter(:location, :@dxml, 'deviceLocation', :to_s)
-    add_getter(:model, :@dxml, 'model', :to_s)
-    add_getter(:serial, :@dxml, 'serialNumber', :to_s)
-    add_getter(:mac_address, :@dxml, 'macAddress', :to_s)
-    add_getter(:firmware_version, :@dxml, 'firmwareVersion', :to_s)
-    add_getter(:encoder_version, :@dxml, 'encoderVersion', :to_s)
-    add_getter(:boot_version, :@dxml, 'bootVersion', :to_s)
-    add_getter(:hardware_version, :@dxml, 'hardwareVersion', :to_s)
-    add_getter(:type, :@dxml, 'deviceType', :to_s)
+    add_getter(:name, :device_info, 'deviceName', :to_s)
+    add_getter(:id, :device_info, 'deviceID', :to_s)
+    add_getter(:description, :device_info, 'deviceDescription', :to_s)
+    add_getter(:location, :device_info, 'deviceLocation', :to_s)
+    add_getter(:model, :device_info, 'model', :to_s)
+    add_getter(:serial, :device_info, 'serialNumber', :to_s)
+    add_getter(:mac_address, :device_info, 'macAddress', :to_s)
+    add_getter(:firmware_version, :device_info, 'firmwareVersion', :to_s)
+    add_getter(:encoder_version, :device_info, 'encoderVersion', :to_s)
+    add_getter(:boot_version, :device_info, 'bootVersion', :to_s)
+    add_getter(:hardware_version, :device_info, 'hardwareVersion', :to_s)
+    add_getter(:type, :device_info, 'deviceType', :to_s)
 
-    add_bool_getter(:support_beep?, :@dxml, 'supportBeep')
-    add_bool_getter(:support_video_loss?, :@dxml, 'supportVideoLoss')
-
-    def load_device_info(options = {})
-      @dxml = @isapi.get_xml('/ISAPI/System/deviceInfo', options).at_xpath('DeviceInfo')
-    end
+    add_bool_getter(:support_beep?, :device_info, 'supportBeep')
+    add_bool_getter(:support_video_loss?, :device_info, 'supportVideoLoss')
   end
 end

--- a/lib/hikvision/system/status.rb
+++ b/lib/hikvision/system/status.rb
@@ -1,19 +1,15 @@
 module Hikvision
   class System
-    attr_reader :sxml
-
     def uptime(options = { cache: false })
       @isapi.get_xml('/ISAPI/System/status', options).at_xpath('DeviceStatus/deviceUpTime').inner_html.to_i
     end
 
-    add_list_getter(:memory_usage, :@sxml, 'MemoryList/Memory/memoryUsage', :to_i)
-    add_list_getter(:memory_available, :@sxml, 'MemoryList/Memory/memoryAvailable', :to_i)
-    add_list_getter(:memory_description, :@sxml, 'MemoryList/Memory/memoryDescription', :to_s)
-    add_list_getter(:cpu_utilization, :@sxml, 'CPUList/CPU/cpuUtilization', :to_i)
-    add_list_getter(:cpu_description, :@sxml, 'CPUList/CPU/cpuDescription', :to_s)
+    add_xml(:status, '/ISAPI/System/status', 'DeviceStatus')
 
-    def load_status(options = {})
-      @sxml = @isapi.get_xml('/ISAPI/System/status', options).at_xpath('DeviceStatus')
-    end
+    add_list_getter(:memory_usage, :status, 'MemoryList/Memory/memoryUsage', :to_i)
+    add_list_getter(:memory_available, :status, 'MemoryList/Memory/memoryAvailable', :to_i)
+    add_list_getter(:memory_description, :status, 'MemoryList/Memory/memoryDescription', :to_s)
+    add_list_getter(:cpu_utilization, :status, 'CPUList/CPU/cpuUtilization', :to_i)
+    add_list_getter(:cpu_description, :status, 'CPUList/CPU/cpuDescription', :to_s)
   end
 end

--- a/lib/hikvision/system/time.rb
+++ b/lib/hikvision/system/time.rb
@@ -7,11 +7,9 @@ module Hikvision
       DateTime.strptime(date, '%Y-%m-%dT%H:%M:%S%z')
     end
 
-    add_getter(:time_zone, :@txml, 'timeZone', :to_s)
-    add_getter(:time_mode, :@txml, 'timeMode', :to_s)
+    add_xml(:time, '/ISAPI/System/time', 'Time')
 
-    def load_time(options = {})
-      @txml = @isapi.get_xml('/ISAPI/System/time', options).at_xpath('Time')
-    end
+    add_getter(:time_zone, :time, 'timeZone', :to_s)
+    add_getter(:time_mode, :time, 'timeMode', :to_s)
   end
 end


### PR DESCRIPTION
the means you _don't_ have to manually call `load_channels` or `load_device_info` before using fields

you can still force a reload with say `load_device_info(cache: false)`, just as before

note that due to generalization, `load_opts` was renamed to `load_capabilities` as part of this